### PR TITLE
#159204705 - Pagination support for articles

### DIFF
--- a/server/controllers/ArticleController.js
+++ b/server/controllers/ArticleController.js
@@ -93,7 +93,14 @@ class ArticleController {
    * @returns {Object} the response body
    */
   static getAllArticle(req, res, next) {
+    let { limit, page } = req.query;
+    limit = +limit < 20 && +limit > 0 ? +limit : 20;
+    page = +page > 0 ? +page : 1;
+    const offset = limit * (page - 1);
+
     Article.findAndCountAll({
+      limit,
+      offset,
       include: [{
         model: User,
         as: 'author',

--- a/server/test/routes/mockData.js
+++ b/server/test/routes/mockData.js
@@ -35,7 +35,6 @@ const mockData = {
     password: 'Bigbadw0lf!'
   },
   user7: {
-    id: 3,
     firstName: 'Strawhat',
     lastName: 'Luffy',
     username: 'strawhat',


### PR DESCRIPTION
#### What does this PR do?
This PR provides pagination functionality for the get all articles route according to a set limit and page number. If no limit or page number is provided a default limit of 20 and page number of 1 is used
#### Description of Task to be completed?
- Define limit and page variables in the get all articles route
- Enable valid limit and page query values set by user to be assigned to the limit and page variables
- put conditions in place prevent invalid query values from being entered by user
- If no values or invalid values are entered limt and page are set to their predefined values
#### How should this be manually tested?
- Clone the repository 
- Run npm install to install all app dependencies
- Setup postgres (if not done already)
- Create a database on postgres
- Run sequelize db:migrate
- Run npm start to start the app
- Test the get all article routes with limit and page query values
   - eg GET api/articles to get all articles?limit=2&page=1

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#159204705
#### Screenshots (if appropriate)
<img width="1244" alt="screen shot 2018-08-20 at 11 04 51 am" src="https://user-images.githubusercontent.com/26818808/44334250-edebae80-a468-11e8-9d8c-be5a7fbed791.png">

#### Questions:
N/A