### PR TITLE
#159204706 Add Search Functionality with custom filters 

### DIFF
--- a/server/controllers/ArticleController.js
+++ b/server/controllers/ArticleController.js
@@ -107,12 +107,14 @@ class ArticleController {
         attributes: [
           'username', 'bio', 'image',
         ],
+        where: req.filterByAuthorAttributes,
       }],
       attributes: [
         'slug', 'title', 'description',
         'body', 'createdAt', 'updatedAt',
       ],
       order: [['createdAt', 'DESC']],
+      where: req.filterByArticleAttributes,
     })
       .then(articles => res.status(200).json({
         articles: articles.rows,

--- a/server/routes/api/articles.js
+++ b/server/routes/api/articles.js
@@ -4,6 +4,7 @@ import validate from '../../utils/middleware/validator/articles';
 import ArticleController from '../../controllers/ArticleController';
 import RatingController from '../../controllers/RatingController';
 import ratingMiddleware from '../../utils/middleware/ratingMiddleware';
+import articleFilters from '../../utils/middleware/articleFilters';
 
 import LikeController from '../../controllers/LikeController';
 
@@ -20,7 +21,7 @@ router.get(
   ArticleController.getArticle,
 );
 router.get(
-  '/articles',
+  '/articles', articleFilters,
   ArticleController.getAllArticle,
 );
 

--- a/server/utils/helpers/filterDateRangeHelper.js
+++ b/server/utils/helpers/filterDateRangeHelper.js
@@ -1,0 +1,33 @@
+const filterDateRangeHelper = (start, end) => {
+  let startDate;
+  let endDate;
+
+  // return date range that covers all articles in the database
+  // if no date query is specified
+  if (!start && !end) {
+    startDate = new Date('2018-07-01');
+    endDate = new Date();
+    // return a specific day range if only startDate is specified
+  } else if (!end) {
+    startDate = new Date(start);
+    endDate = new Date(`${start}T23:59:59.00Z`);
+    // return a specific day range if only endDate is specified
+  } else if (!start) {
+    startDate = new Date(end);
+    endDate = new Date(`${end}T23:59:59.00Z`);
+  } else {
+    // return  specified date range
+    startDate = new Date(start);
+    endDate = new Date(`${end}T23:59:59.00Z`);
+  }
+
+  // set invalid date value(s) to default date values
+  startDate = startDate.toString() !== 'Invalid Date' ? startDate
+    : new Date('2018-07-01');
+  endDate = endDate.toString() !== 'Invalid Date' ? endDate
+    : new Date();
+
+  return [startDate, endDate];
+};
+
+export default filterDateRangeHelper;

--- a/server/utils/middleware/articleFilters.js
+++ b/server/utils/middleware/articleFilters.js
@@ -1,0 +1,52 @@
+import Sequelize from 'sequelize';
+import dateRange from '../helpers/filterDateRangeHelper';
+
+// get the sequelize operator object
+const { Op } = Sequelize;
+
+const articleFilters = (req, res, next) => {
+  const {
+    title, description, body, startDate, endDate,
+    username, firstName, lastName,
+  } = req.query;
+
+  req.filterByArticleAttributes = {
+    [Op.and]: [
+      {
+        title: {
+          [Op.like]: `%${title || ''}%`,
+        },
+      },
+      {
+        description: {
+          [Op.like]: `%${description || ''}%`,
+        },
+      },
+      {
+        body: {
+          [Op.like]: `%${body || ''}%`,
+        },
+      },
+      {
+        createdAt: {
+          [Op.between]: dateRange(startDate, endDate),
+        },
+      },
+    ],
+  };
+
+  req.filterByAuthorAttributes = {
+    username: {
+      [Op.like]: `%${username || ''}%`,
+    },
+    firstName: {
+      [Op.like]: `%${firstName || ''}%`,
+    },
+    lastName: {
+      [Op.like]: `%${lastName || ''}%`,
+    },
+  };
+  return next();
+};
+
+export default articleFilters;


### PR DESCRIPTION
#### What does this PR do?
- This PR adds search functionality with custom filters

#### Description of Task to be completed?
- ensure articles can be filtered by `title` query
- ensure articles can be filtered by `description` query
- ensure articles can be filtered by `body` query
- ensure articles can be filtered by creation date using the `startDate` and `endDate` query
- ensure articles can be filtered by authors `username`, `firstName`, `lastName`
- ensure articles can be filtered by the combination of any of the attributes mentioned above

#### How should this be manually tested?
- run `npm start` 
- Using Postman add any combination of the queries to the get all articles route e.g `http://localhost:3000/api/articles?startDate=2018-08-17&endDate=2018-08-20&username=user5`.

#### Any background context you want to provide?
- specify valid date values to `startDate` and `endDate` to get articles between the date range (eg. `startDate=2018-08-17&endDate=2018-08-20`). Date range must be from the smallest (oldest) to the largest (newest).

- Specify values for only one of the date fields to get articles created in a specific date (e.g. `startDate=2018-08-17`). 

#### What are the relevant pivotal tracker stories?
#159204706