### PR TITLE
#159846051: add tests for login and improve overall test coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 /node_modules/**
 /coverage/**
 server/database/**
-server/test/**
+server/test/**/*.test.js
 .env
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ node_modules
 .nyc_output
 
 .client
+
+/**/*.icloud

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "validatorjs": "^3.14.2"
   },
   "devDependencies": {
-    "nyc": "^12.0.2",
     "babel-cli": "^6.26.0",
     "babel-istanbul": "^0.12.2",
     "babel-preset-env": "^1.7.0",
@@ -69,16 +68,17 @@
     "chai-http": "^4.0.0",
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
-    "eslint-config-airbnb": "^17.0.0",
-    "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.10.0",
     "eslint": "^5.2.0",
+    "eslint-config-airbnb": "^17.0.0",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-react": "^7.10.0",
     "faker": "^4.1.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "nodemon": "^1.18.3",
+    "nyc": "^12.0.2",
     "underscore": "^1.9.1"
   }
 }

--- a/server/configs/passport.js
+++ b/server/configs/passport.js
@@ -19,18 +19,14 @@ passport.use(
         .findOne({ where: { email } })
         .then((user) => {
           if (!user) {
-            return done(null, false, {
-              errors: { email: 'is invalid' },
-            });
+            return done(null, false);
           }
 
           const hash = crypto
             .pbkdf2Sync(password, user.salt, 10000, 512, 'sha512')
             .toString('hex');
           if (!(hash === user.hash)) {
-            return done(null, false, {
-              errors: { password: 'is invalid' },
-            });
+            return done(null, false);
           }
           return done(null, user);
         })

--- a/server/controllers/LikeController.js
+++ b/server/controllers/LikeController.js
@@ -101,7 +101,7 @@ class LikeController {
    * sent to the server
    * @param {object} res used to send a response back to the
    * client
-   * @param {object} next called when an error occurs while
+   * @param {object} next called  when an error occurs while
    * querying the database
    * @returns {void} does not return a value to the user
    */

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -68,8 +68,9 @@ class UserController {
   static login(req, res, next) {
     return passport.authenticate(
       'local', { session: false },
-      (err, user, info) => {
+      (err, user) => {
         if (err) return next(err);
+
         if (user) {
           const payload = {
             id: user.id,
@@ -81,30 +82,12 @@ class UserController {
             user: userControllerHelper.userDetails(user, token),
           });
         }
-        return res.status(422)
-          .json(info);
+        return errorHelper
+          .throwError('email and password combination not found', 400);
       },
     )(req, res, next);
   }
 
-  /**
-   * Get the details of a logged in user
-   * @param {Object} req the request body
-   * @param {Object} res the response body
-   * @param {function} next a call to the next function
-   * @returns {Object} the response body
-   */
-  static get(req, res, next) {
-    const { id } = req.body.decoded;
-    User.findById(id)
-      .then((user) => {
-        if (!user) {
-          errorHelper.decoded('User not found', 404);
-        }
-        return res
-          .json({ user: userControllerHelper.userDetails(user) });
-      }).catch(next);
-  }
 
   /**
    * Method updates an existing user information in the database.

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -7,12 +7,6 @@ import AuthMiddleware from '../../utils/middleware/AuthMiddleware';
 
 const router = Router();
 
-router.get(
-  '/user',
-  AuthMiddleware.authenticateUser,
-  UserController.get,
-);
-
 router.put(
   '/user',
   AuthMiddleware.authenticateUser,

--- a/server/test/routes/mockData.js
+++ b/server/test/routes/mockData.js
@@ -41,6 +41,25 @@ const mockData = {
     email: 'strawhat@gmail.com',
     password: 'Bigbadw0lf!',
   },
+
+  user8: {
+    firstName: 'NewFirstName',
+    lastName: 'NewLastName',
+    username: 'usernameIsHere',
+    email: 'newemail@gmail.com',
+    password: 'Bigbadw0lf!',
+    bio: 'newBio',
+    image: 'http://thisisaurl/image.png',
+  },
+  existingUser: {
+    firstName: 'thisUserFirstName',
+    lastName: 'thisUserLastName',
+    username: 'thisuserexists',
+    email: 'thisuserexists@gmail.com',
+    hash: 'BigbGadw0lf!',
+    password: 'BigbGadw0lf!',
+    bio: 'whatabio',
+  },
   likeUser: {
     firstName: 'Chidiebere',
     lastName: 'TheGreat',
@@ -192,7 +211,7 @@ const mockData = {
     body: 'article notification',
     slug: 'article-notification',
     authorId: 'fbf941c0-aa8c-11e8-a375-d331f0a71356',
-  }
+  },
 };
 
 export default mockData;


### PR DESCRIPTION
#### What does this PR do?
- adds tests for login route (POST /api/users/login)
- removes unnecessary route that gets a user GET (/users)
- improves overall test coverage
- adds validator to the login route

#### Description of Task to be completed?
- add test for login route
- improve overall test coverage

#### How should this be manually tested?
- run `npm test` from your console to see the new test coverage

#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
- 159846051

#### Screenshots (if appropriate)
<img width="1107" alt="screen shot 2018-08-27 at 5 59 07 pm" src="https://user-images.githubusercontent.com/38565349/44673288-050b3d00-aa23-11e8-868e-e74232cb9e75.png">

#### Questions:
- None