### PR TITLE
Users should be redirected to frontend login page upon successful social login 

### DIFF
--- a/server/controllers/OauthController.js
+++ b/server/controllers/OauthController.js
@@ -1,5 +1,6 @@
 
 import crypto from 'crypto';
+import url from 'url';
 import { User } from '../database/models'; //eslint-disable-line
 import tokenService from '../utils/services/tokenService';
 
@@ -64,19 +65,19 @@ class OauthController {
       id: user.id,
       email: user.email,
     }, '3d');
-    res.json({
-      status: 'success',
-      data: {
+
+    res.redirect(url.format({
+      pathname: process.env.CLIENT_PATH,
+      query: {
         email: user.email,
         image: user.image,
         firstName: user.firstName,
         lastName: user.lastName,
         bio: user.bio,
-        token,
         username: user.username,
+        token,
       },
-      message: 'Successfully authenticated the user',
-    });
+    }));
   }
 }
 

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -194,8 +194,7 @@ class UserController {
       }
       const token = tokenService
         .generateToken({ id: user.id, username: user.username }, 1800);
-      let url = `${process.env.BASEURL}`;
-      url += `/api/users/reset-password?token=${token}`;
+      const url = `${req.headers.origin}/reset-password?token=${token}`;
       const mailOptions = emailService.mailOptions(
         user.email,
         "Authors Heaven's account token",


### PR DESCRIPTION
#### What does this PR do?
This PR redirects users to the login page of this project's frontend implementation upon sucessfull login
#### Description of Task to be completed?
- configure social login to redirect to the login url of this project's frontend implementation upon successful login
- send user information and token needed from successful login via url query parameters
#### How should this be manually tested?
- Clone the repository
- Run npm install to install all app dependencies
- Setup postgres (if not done already)
- Create a database on postgres
- Run sequelize db:migrate
- Run npm start to start the app
- Test the following routes
  - `GET /auth/google` to request authentication/login from google
  - `GET /auth/linkedin` to request authentication/login from linkedIn
  - `GET /auth/facebook` to request authentication/login from facebook
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
<img width="1416" alt="screen shot 2018-09-13 at 5 49 00 am" src="https://user-images.githubusercontent.com/26818808/45467702-cd85db80-b718-11e8-93aa-15e4c730539d.png">
#### Questions:
N/A

