### PR TITLE
fix(create): user should create article with image

### DIFF
--- a/server/controllers/ArticleController.js
+++ b/server/controllers/ArticleController.js
@@ -33,7 +33,7 @@ class ArticleController {
    */
   static createArticle(req, res, next) {
     const {
-      title, description, body, tags,
+      title, description, body, tags, image,
     } = req.body.article;
     // generating a slug
     const id = uuid();
@@ -44,10 +44,10 @@ class ArticleController {
     const subcategoryName = req.body.subcategoryDetails
       ? req.body.subcategoryDetails.name : 'OTHERS';
     const {
-      username, bio, image,
+      username, bio,
     } = req.user;
     const newArticle = {
-      id, slug, title, description, body, authorId, subcategoryId,
+      id, slug, title, description, body, authorId, subcategoryId, image,
     };
     Article.create(newArticle)
       .then((article) => {


### PR DESCRIPTION
#### What does this PR do?
- adds image to the parameters for creating an article

#### Description of Task to be completed?
- user should specify article cover photo when creating the article

#### How should this be manually tested?
- hit route `POST /articles` with this sample body
```
{
	"article":{
		"title":"after code change",
		"description":"Talking about work life balance",
		"body":"there is need for us to go home to our family as quick as we can",
		"image": "imageUrl"
	}
}
```
- you should create an article with image equal to the imageUrl specified

#### Any background context you want to provide?
- Route is protected you would need authorization

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)
<img width="1035" alt="screen shot 2018-09-18 at 11 49 06 am" src="https://user-images.githubusercontent.com/38565349/45682674-e5a29400-bb38-11e8-9ab9-fcf0c80982ab.png">
![Uploading Screen Shot 2018-09-18 at 11.48.54 AM.png…]()


#### Questions:
- none
