### PR TITLE
#160827340 fix null values returned when getting comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "posttest": "sequelize --env test db:migrate:undo:all",
     "migrate": "sequelize db:migrate",
     "undo:migrate": "sequelize db:migrate:undo:all",
+    "seed": "sequelize db:seed --seed 20180724134320-categories.js",
+    "seed2": "sequelize db:seed --seed 20180724134927-subcategories.js ",
+    "migrating": "sequelize db:migrate:undo:all && sequelize db:migrate",
     "unmigrate-test": "sequelize --env test db:migrate:undo:all",
     "migrate-staging": " sequelize --env staging db:migrate:undo:all && sequelize --env staging  db:migrate"
   },

--- a/server/utils/helpers/queryHelper.js
+++ b/server/utils/helpers/queryHelper.js
@@ -4,21 +4,20 @@ const getComments = (articleId, limit, offset) => `WITH
 main_commenttable AS (SELECT * FROM "Users" userstable INNER JOIN 
 (SELECT * FROM "Comments" commenttable1 LEFT JOIN 
 (SELECT "parentId" "parentid", count(*) "repliesCount" FROM 
-"Comments" GROUP BY "parentId") commenttable2 ON 
-commenttable2."parentid" = commenttable1.id 
-WHERE commenttable1.type = 'main' AND 
-commenttable1."articleId" = ANY('{${articleId}}'))
-commenttablefinal ON commenttablefinal."authorId" = 
-userstable.id ORDER BY commenttablefinal."createdAt"), 
-count_comments AS (SELECT count(*)
-AS "totalCount" FROM main_commenttable) 
-SELECT * FROM main_commenttable, count_comments
-LIMIT ${limit} OFFSET ${offset};`;
+  "Comments" GROUP BY "parentId") commenttable2 ON 
+  commenttable2."parentid" = commenttable1.id 
+  WHERE commenttable1.type = 'main' AND 
+  commenttable1."articleId" = ANY('{${articleId}}'))
+   commenttablefinal ON commenttablefinal."authorId" = 
+   userstable.id ORDER BY commenttablefinal."createdAt"), 
+   count_comments AS (SELECT count(*) AS "totalCount" FROM main_commenttable) 
+   SELECT * FROM main_commenttable, 
+   count_comments LIMIT ${limit} OFFSET ${offset};`;
 
 // query the database to get replies and total replies of a comment,
 // including the owner and reply count of each reply
 const getReplies = (articleId, parentId, limit, offset) => `WITH 
-main_commenttable AS (SELECT * FROM "Users" userstable LEFT JOIN 
+main_commenttable AS (SELECT * FROM "Users" userstable INNER JOIN 
 (SELECT * FROM "Comments" commenttable1 LEFT JOIN 
 (SELECT "parentId" "parentid", count(*) "repliesCount" FROM 
 "Comments" GROUP BY "parentId") commenttable2 ON 
@@ -26,12 +25,11 @@ commenttable2."parentid" = commenttable1.id
 WHERE commenttable1.type = 'reply' AND 
 commenttable1."articleId" = ANY('{${articleId}}') 
 AND commenttable1."parentId" = ANY('{${parentId}}'))
-commenttablefinal ON commenttablefinal."authorId" = 
-userstable.id ORDER BY commenttablefinal."createdAt"), 
-count_comments AS (SELECT count(*) AS
-"totalCount" FROM main_commenttable)  
-SELECT * FROM main_commenttable, count_comments
-LIMIT ${limit} OFFSET ${offset};`;
+ commenttablefinal ON commenttablefinal."authorId" = 
+ userstable.id ORDER BY commenttablefinal."createdAt"), 
+ count_comments AS (SELECT count(*) AS "totalCount" FROM main_commenttable) 
+ SELECT * FROM main_commenttable, 
+ count_comments LIMIT ${limit} OFFSET ${offset};`;
 
 // get a single comment, including the owner and reply count of the comment
 const getComment = commentId => `SELECT * FROM "Users" 


### PR DESCRIPTION
#### What does this PR do?
- Fix null value returned when getting comments from the database

#### Description of Task to be completed?
- Modify the query to get comment and replies to comments
- I Also add scripts to package.json to make for seeding the database category and subcategory of articles

#### Any background context you want to provide?
- The query to get comments returns an array of comments based on the users found in the database. This irrespective of whether the users actually commented or not. The present query results in rows of event comments with values set to null making it difficult to walk with and actually track the comment details. The screenshot below shows an example of this condition

#### What are the relevant pivotal tracker stories?
#160827340

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30448913/46179625-0fd02080-c2b4-11e8-8d6c-210fe00365c5.png)

![image](https://user-images.githubusercontent.com/30448913/46179634-1b234c00-c2b4-11e8-8e5c-409e8e309de8.png)

#### After the fix
![image](https://user-images.githubusercontent.com/30448913/46179659-2fffdf80-c2b4-11e8-8ce9-9b35fab4f55f.png)

